### PR TITLE
add ability to break on warnings without throwing an error

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ Default: `false`
 
 If true, will throw an error if any warnings or errors were found.
 
+### breakOnWarning
+
+Type: `boolean`  
+Default: `false`
+
+If true, will stop rollup if any warnings or errors were found without throwing an error. This helps to have clean warnings and errors from eslint without adding error stack trace.
+
 ### include
 
 Type: `array` or `string`  

--- a/README.md
+++ b/README.md
@@ -41,13 +41,6 @@ Default: `false`
 
 If true, will throw an error if any warnings or errors were found.
 
-### breakOnWarning
-
-Type: `boolean`  
-Default: `false`
-
-If true, will stop rollup if any warnings or errors were found without throwing an error. This helps to have clean warnings and errors from eslint without adding error stack trace.
-
 ### include
 
 Type: `array` or `string`  

--- a/src/index.js
+++ b/src/index.js
@@ -43,6 +43,13 @@ export default function eslint(options = {}) {
                 err.name = 'ESLintError';
                 throw err;
             }
+
+            if (options.breakOnWarning) {
+                const err = Error(' ');
+                err.name = ' ';
+                err.stack = null;
+                throw err;
+            }
         }
     };
 }

--- a/src/index.js
+++ b/src/index.js
@@ -41,12 +41,6 @@ export default function eslint(options = {}) {
                     'Warnings or errors were found'
                 );
                 err.name = 'ESLintError';
-                throw err;
-            }
-
-            if (options.breakOnWarning) {
-                const err = Error(' ');
-                err.name = ' ';
                 err.stack = null;
                 throw err;
             }

--- a/test/eslint.js
+++ b/test/eslint.js
@@ -64,22 +64,6 @@ test('should fail with enabled throwError option', t => {
         t.fail('should throw error');
     }).catch(err => {
         t.is(err.toString(), 'ESLintError: Warnings or errors were found');
-    });
-});
-
-test('should fail without trace with enabled breakOnWarning option', t => {
-    return rollup({
-        entry: 'fixtures/use-strict.js',
-        plugins: [
-            eslint({
-                breakOnWarning: true,
-                formatter: () => ''
-            })
-        ]
-    }).then(() => {
-        t.fail('should throw error');
-    }).catch(err => {
-        t.is(err.toString(), ' :  ');
         t.is(err.stack, null);
     });
 });

--- a/test/eslint.js
+++ b/test/eslint.js
@@ -66,3 +66,20 @@ test('should fail with enabled throwError option', t => {
         t.is(err.toString(), 'ESLintError: Warnings or errors were found');
     });
 });
+
+test('should fail without trace with enabled breakOnWarning option', t => {
+    return rollup({
+        entry: 'fixtures/use-strict.js',
+        plugins: [
+            eslint({
+                breakOnWarning: true,
+                formatter: () => ''
+            })
+        ]
+    }).then(() => {
+        t.fail('should throw error');
+    }).catch(err => {
+        t.is(err.toString(), ' :  ');
+        t.is(err.stack, null);
+    });
+});


### PR DESCRIPTION
Add option `breakOnWarning`, which is very much similar to `throwError` except that with `breakOnWarning` we wont throw an error that pollutes the warning or error information from eslint.

fixes https://github.com/TrySound/rollup-plugin-eslint/issues/3 @TrySound 
