### PR TITLE
Move Eslint as a peer dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "0.12"
   - "4"
   - "5"
   - "6"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 ## Install
 
 ```sh
-npm i rollup-plugin-eslint -D
+npm i eslint rollup-plugin-eslint -D
 ```
 
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,11 @@
     "url": "https://github.com/TrySound/rollup-plugin-eslint/issues"
   },
   "homepage": "https://github.com/TrySound/rollup-plugin-eslint#readme",
+  "engines": {
+    "node": ">=4"
+  },
   "devDependencies": {
+    "eslint": "^3.0.0",
     "buble": "^0.10.6",
     "mocha": "^2.5.3",
     "rollup": "^0.31.1",
@@ -38,7 +42,9 @@
     "rollup-plugin-node-resolve": "^1.7.0"
   },
   "dependencies": {
-    "eslint": "^2.0.0",
     "rollup-pluginutils": "^1.3.1"
+  },
+  "peerDependencies": {
+    "eslint": ">=2.0.0 <4.0.0"
   }
 }


### PR DESCRIPTION
Moving `eslint` as a peer dependency as discussed in #9.
Note: `eslint >= 3.0.0` drop support for `node < 4`.
