### PR TITLE
PR for optionally passing eslint config file to plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,8 +11,9 @@ function normalizePath(id) {
 
 function eslint(options = {}) {
   if (typeof options === 'string') {
-    const configFile = path.resolve(process.cwd(), options)
-    options = require(configFile)
+    const configFile = path.resolve(process.cwd(), options);
+    options = require(configFile);
+    options.useEslintrc = false; // Tell eslint not to look for configuration files.
   }
 
   const cli = new CLIEngine(options);

--- a/index.js
+++ b/index.js
@@ -10,6 +10,11 @@ function normalizePath(id) {
 }
 
 function eslint(options = {}) {
+  if (typeof options === 'string') {
+    const configFile = path.resolve(process.cwd(), options)
+    options = require(configFile)
+  }
+
   const cli = new CLIEngine(options);
   let formatter = options.formatter;
 


### PR DESCRIPTION
PR to allow a string to be passed for specific config files; primarily to allow different Rollup configs to have different linting rules. See #25 

Example use:
```
import { eslint } from 'rollup-plugin-eslint'

export default {
  input: 'lib/index.js',
  output: {
    file: 'build/build.js',
    format: 'iife',
  },

  plugins: [
    eslint('config/dev.eslintrc.js'),
  ],
}
```