### PR TITLE
Changed the order files get checked for ignoring

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ function eslint(options = {}) {
 
     transform(code, id) {
       const file = normalizePath(id);
-      if (cli.isPathIgnored(file) || !filter(id)) {
+      if (!filter(id) || cli.isPathIgnored(file)) {
         return null;
       }
 


### PR DESCRIPTION
This allows the plugin to have greater control on what ESLint gets to see and not.

For more information see #37 