### PR TITLE
Update doc about passing eslint file as path to plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,19 @@ export default {
 };
 ```
 
+**Note:** You can pass a relative path to your eslint config file 
+```js
+import { rollup } from "rollup";
+import { eslint } from "rollup-plugin-eslint";
+
+export default {
+  input: "main.js",
+  plugins: [
+    eslint('./path-to-my-eslintconfig')
+  ]
+};
+```
+
 ## Options
 
 See more options here [eslint-config].


### PR DESCRIPTION
A fairly small edit on the doc to let users know they can also configure their eslint plugin by passing a relative path to their eslint config. 